### PR TITLE
Fix bleed trim

### DIFF
--- a/image-effects/pom.xml
+++ b/image-effects/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.kemitix.clover</groupId>
         <artifactId>clover-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/image-io/pom.xml
+++ b/image-io/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.kemitix.clover</groupId>
         <artifactId>clover-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/images/pom.xml
+++ b/images/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.kemitix.clover</groupId>
         <artifactId>clover-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/issue-cover/pom.xml
+++ b/issue-cover/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.kemitix.clover</groupId>
         <artifactId>clover-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/issue-cover/src/main/java/net/kemitix/clover/issue/LogoStraps.java
+++ b/issue-cover/src/main/java/net/kemitix/clover/issue/LogoStraps.java
@@ -67,7 +67,8 @@ public class LogoStraps extends AbstractElement {
                 .vAlign(TextEffect.VAlignment.TOP)
                 .hAlign(TextEffect.HAlignment.LEFT)
                 .region(Region.builder()
-                        .top(top).left(left + issueDimensions.getFrontCrop().getLeft())
+                        .top(top)
+                        .left(left + issueDimensions.getFrontCrop().getLeft() + 30)
                         .width(issueDimensions.getFrontCrop().getWidth() -
                                 (left + issueDimensions.getFrontCrop().getLeft()))
                         .height(issueDimensions.getFrontCrop().getHeight() - top)

--- a/issue-cover/src/main/java/net/kemitix/clover/issue/LogoStraps.java
+++ b/issue-cover/src/main/java/net/kemitix/clover/issue/LogoStraps.java
@@ -37,8 +37,10 @@ public class LogoStraps extends AbstractElement {
                 .text("Science Fiction and Fantasy")
                 .vAlign(TextEffect.VAlignment.TOP)
                 .hAlign(TextEffect.HAlignment.RIGHT)
-                .region(issueDimensions.getFrontCrop().toBuilder()
-                        .top(10).build().withPadding(85))
+                .region(issueDimensions.getFrontCrop()
+                        .withTop(10)
+                        .withWidth(w -> w - 30)
+                        .withPadding(85))
                 ;
     }
 
@@ -49,8 +51,9 @@ public class LogoStraps extends AbstractElement {
                 .text(issueConfig.getDate())
                 .vAlign(TextEffect.VAlignment.TOP)
                 .hAlign(TextEffect.HAlignment.RIGHT)
-                .region(issueDimensions.getFrontCrop().toBuilder()
-                        .top(top).build()
+                .region(issueDimensions.getFrontCrop()
+                        .withTop(top)
+                        .withWidth(w -> w - 30)
                         .withPadding(85))
                 ;
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -14,7 +14,7 @@
     <groupId>net.kemitix.clover</groupId>
     <artifactId>clover-parent</artifactId>
     <name>clover-parent</name>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>net.kemitix.clover</groupId>
     <artifactId>clover-root</artifactId>
     <name>clover-root</name>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/runner/pom.xml
+++ b/runner/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>net.kemitix.clover</groupId>
         <artifactId>clover-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
         <relativePath>../parent</relativePath>
     </parent>
 
     <artifactId>clover-runner</artifactId>
     <name>clover-runner</name>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 
     <dependencies>
         <!-- clover -->

--- a/runner/src/main/resources/application.properties
+++ b/runner/src/main/resources/application.properties
@@ -4,7 +4,7 @@ clover.width=5
 clover.height=8
 # clover.trim is with outside margin that Amazon KDP will cut from the printed sheet
 # https://kdp.amazon.com/en_US/help/topic/G201953020#size
-clover.trim=0.25
+clover.trim=0.35
 clover.dpi=320
 clover.drop-shadow-x-offset=3
 clover.drop-shadow-y-offset=0

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>net.kemitix.clover</groupId>
         <artifactId>clover-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
         <relativePath>../parent</relativePath>
     </parent>
 
     <artifactId>clover-service</artifactId>
     <name>clover-service</name>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 
     <dependencies>
         <dependency>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.kemitix.clover</groupId>
         <artifactId>clover-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/story-cards/pom.xml
+++ b/story-cards/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.kemitix.clover</groupId>
         <artifactId>clover-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.1.1</version>
         <relativePath>../parent</relativePath>
     </parent>
 


### PR DESCRIPTION
KDP objected to the paperback cover being a little bit too small. Strap lines then extended too close to the edge once rescaled so they were brought in slightly (to where they should have been anyway)