### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test:
 	mvn test ${RUN_PARAMS}
 
 issue-dir:
-	@test ${ISSUE_DIR}
+	@test ${CLOVER_DIR}
 
 dev: issue-dir build
 	mvn -pl runner quarkus:dev ${RUN_PARAMS}

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ issue-dir:
 dev: issue-dir build
 	mvn -pl runner quarkus:dev ${RUN_PARAMS}
 
-run: issue-dir build
+run: issue-dir install
 	( \
 		cd runner/target/quarkus-app && \
 		java \

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ graphs:
 install: .install
 
 .install:
-	mvn install -DskipTests -Dpitest.skip
+	mvn install
 	touch .install
 
 build:


### PR DESCRIPTION
- `make install` now runs tests - don't install anything that is failing tests
- `make issue-dir` now checks for the `CLOVER_DIR` environment variable - ISSUE_DIR has been removed
- `make run` now depends on run rather than build - avoid rebuilding everytime