### PR TITLE
Bump itextpdf.version from 7.2.1 to 7.2.3

### DIFF
--- a/image-io/pom.xml
+++ b/image-io/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>clover-image-io</artifactId>
 
     <properties>
-        <itextpdf.version>7.2.1</itextpdf.version>
+        <itextpdf.version>7.2.3</itextpdf.version>
         <webp-imageio.version>0.1.6</webp-imageio.version>
     </properties>
 


### PR DESCRIPTION
Bumps `itextpdf.version` from 7.2.1 to 7.2.3.

Updates `pdfa` from 7.2.1 to 7.2.3

Updates `layout` from 7.2.1 to 7.2.3

---
updated-dependencies:
- dependency-name: com.itextpdf:pdfa
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: com.itextpdf:layout
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

commit-id:ef1aa2fb

---

**Stack**:
- #294
- #293
- #292
- #291
- #290
- #289
- #288 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*