### PR TITLE
Bump imageio-jpeg from 3.8.1 to 3.8.3

### DIFF
--- a/image-io/pom.xml
+++ b/image-io/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-jpeg</artifactId>
-            <version>3.8.1</version>
+            <version>3.8.3</version>
             <!-- FIXME: This not being registered correctly -->
         </dependency>
         <dependency>


### PR DESCRIPTION
Bumps imageio-jpeg from 3.8.1 to 3.8.3.

---
updated-dependencies:
- dependency-name: com.twelvemonkeys.imageio:imageio-jpeg
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

commit-id:7f79a244

---

**Stack**:
- #298
- #296
- #294 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*