### PR TITLE
Bump mockito.version from 4.8.0 to 4.9.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -31,7 +31,7 @@
         <assertj.version>3.23.1</assertj.version>
         <file-reader-writer.version>1.0.0</file-reader-writer.version>
         <lombok.version>1.18.24</lombok.version>
-        <mockito.version>4.8.0</mockito.version>
+        <mockito.version>4.9.0</mockito.version>
         <typed-properties.version>1.0.0</typed-properties.version>
         <text-wrap-fit-box.version>1.0.0</text-wrap-fit-box.version>
         <fontface.version>1.1.2</fontface.version>


### PR DESCRIPTION
Bumps `mockito.version` from 4.8.0 to 4.9.0.

Updates `mockito-junit-jupiter` from 4.8.0 to 4.9.0
- [Release notes](https://github.com/mockito/mockito/releases)
- [Commits](https://github.com/mockito/mockito/compare/v4.8.0...v4.9.0)

Updates `mockito-core` from 4.8.0 to 4.9.0
- [Release notes](https://github.com/mockito/mockito/releases)
- [Commits](https://github.com/mockito/mockito/compare/v4.8.0...v4.9.0)

---
updated-dependencies:
- dependency-name: org.mockito:mockito-junit-jupiter
  dependency-type: direct:production
  update-type: version-update:semver-minor
- dependency-name: org.mockito:mockito-core
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

commit-id:4363cc23