### PR TITLE
Bump imageio-jpeg from 3.9.3 to 3.9.4

### DIFF
--- a/image-io/pom.xml
+++ b/image-io/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-jpeg</artifactId>
-            <version>3.9.3</version>
+            <version>3.9.4</version>
             <!-- FIXME: This not being registered correctly -->
         </dependency>
         <dependency>


### PR DESCRIPTION
Bumps imageio-jpeg from 3.9.3 to 3.9.4.

---
updated-dependencies:
- dependency-name: com.twelvemonkeys.imageio:imageio-jpeg
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

commit-id:69bc0116